### PR TITLE
Added support for the X-Request-Id header

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Your hapi site will see the incoming HTTP request as coming from the IP address 
 #### Client Port ####
 Your hapi site will see the incoming HTTP request as coming from the PORT that hapi is running on inside the Heroku platform (which is rarely the port your site is running on - i.e. 80 or 443). In the majority of cases you most likely are interested in the port that the client is connecting on. By default this plugin sets `request.info.remotePort` to the value of the `x-forwarded-port` header which Heroku sets to the originating port (see `remotePortToClientPort` setting)
 
+#### Request ID ####
+Your hapi site will generate an unique identifier for each incoming request. By default this plugin sets the `request.id` to the value of the `x-request-id` header which Heroku already generates for each incoming request (see `mapRequestId` setting)
 
 ### Options
 
@@ -30,6 +32,7 @@ The following options are available:
 
 * `remotePortToClientPort`: if `true`, will set `request.info.remoteAddress` to the value of the `x-forwarded-port` header if it exists and is non-empty. Heroku set the `x-forwarded-port` header to the originating port of the HTTP request (example: 443). Defaults to `true`.
 
+* `mapRequestId`: if `true`, will set `request.id` to the value of the `x-request-id` header if it exists and is non-empty. Heroku set the `x-request-id` header to an unique identifier per request. This setting allows you to map any request logged by Heroku to a request received by your application. Defaults to `true`.
 
 ### Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,14 @@ const internals = {
     defaults: {
         redirectHttpToHttps: true,
         remoteAddressToClientIp: true,
-        remotePortToClientPort: true
+        remotePortToClientPort: true,
+        mapRequestId: true
     },
     options: Joi.object ({
         redirectHttpToHttps: Joi.boolean(),
         remoteAddressToClientIp: Joi.boolean(),
-        remotePortToClientPort: Joi.boolean()
+        remotePortToClientPort: Joi.boolean(),
+        mapRequestId: Joi.boolean()
     })
 };
 
@@ -56,6 +58,10 @@ exports.register = function (server, options, next) {
         if(settings.remotePortToClientPort) {
 
             request.info.remotePort = request.headers['x-forwarded-port'] || request.info.remotePort;
+        }
+
+        if(settings.mapRequestId) {
+            request.id = request.headers['x-request-id'] || request.id;
         }
 
         // Heroku terminates ssl at the edge of the network so your hapi site will


### PR DESCRIPTION
Hi there,

I've added support for mapping the X-Request-Id header generated by Heroku to the Hapi requesst id.

Cheers,
Robin